### PR TITLE
users redirected to contact page for signup and app homepage for login

### DIFF
--- a/components/hero-home.tsx
+++ b/components/hero-home.tsx
@@ -1,6 +1,7 @@
 // import VideoThumb from "@/public/images/hero-image-01.jpg";
 // import ModalVideo from "@/components/modal-video";
 import Process from "@/components/process";
+import Link from "next/link";
 
 export default function HeroHome() {
   return (
@@ -69,14 +70,14 @@ export default function HeroHome() {
                   data-aos="zoom-y-out"
                   data-aos-delay={450}
                 >
-                  <a
+                  <Link
                     className="btn group mb-4 w-full bg-purple-500 hover:bg-purple-100 text-white hover:text-black shadow hover:bg-[length:100%_150%] sm:mb-0 sm:w-auto"
-                    href="#0"
+                    href="/contact"
                   >
                     <span className="relative inline-flex items-center">
                       Start Free Trial
                     </span>
-                  </a>
+                  </Link>
                   <a
                     className="btn w-full bg-white text-gray-800 shadow hover:bg-gray-800 hover:text-gray-200 sm:ml-4 sm:w-auto"
                     href="/help/frequently-asked-questions"

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -106,16 +106,17 @@ export default function Header() {
           {/* Desktop sign in links */}
           <ul className="flex flex-1 items-center justify-end gap-3">
             <li>
-              <Link
-                href="/signin"
+              <a
+                href="https://app.kubespaces.io"
                 className="btn-sm bg-white text-gray-800 shadow hover:bg-gray-50"
+                rel="noopener noreferrer"
               >
                 Login
-              </Link>
+              </a>
             </li>
             <li>
               <Link
-                href="/signup"
+                href="/contact"
                 className="btn-sm bg-purple-500 text-gray-200 shadow hover:bg-gray-900"
               >
                 Register


### PR DESCRIPTION
### :bulb: PR Summary generated by FirstMate

**Overview**: Redirect users to the contact page for signup and app homepage for login.

**Changes**:
*Hero Component Updates:*
- Replaced `<a>` tag with `<Link>` component for the "Start Free Trial" button, linking to `/contact`.
  
*Header Component Updates:*
- Changed the "Login" link from `<Link>` to `<a>`, pointing to the external app homepage.
- Updated the "Register" link to redirect to the `/contact` page instead of `/signup`.

**TLDR**: Users are now redirected to the contact page for signup and the app homepage for login. Focus on the changes in `hero-home.tsx` and `header.tsx`.

<sub><sup>Generated by FirstMate and automatically updated on every commit.</sup></sub>